### PR TITLE
refactored gridfs upload and download functions

### DIFF
--- a/coroutines/src/main/kotlin/gridfs/MongoBucketExtensions.kt
+++ b/coroutines/src/main/kotlin/gridfs/MongoBucketExtensions.kt
@@ -19,6 +19,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
+import org.cufy.bson.BsonDocument
+import org.cufy.bson.BsonDocumentBlock
 import org.cufy.bson.BsonElement
 import org.cufy.bson.BsonObjectId
 import org.cufy.mongodb.ClientSession
@@ -44,6 +46,7 @@ over the same functions in `MongoBucket.kt`
  *
  * @param session the client session with which to associate this operation.
  * @param filename the filename.
+ * @param metadata user provided data for the `metadata` field of the files collection document.
  * @param options  the upload options.
  * @return an upload instance to complete the upload process.
  * @see com.mongodb.reactivestreams.client.gridfs.GridFSBucket.uploadFromPublisher
@@ -51,13 +54,14 @@ over the same functions in `MongoBucket.kt`
  */
 suspend fun MongoBucket.asyncUpload(
     filename: String,
+    metadata: BsonDocument = BsonDocument.Empty,
     options: UploadOptions = UploadOptions(),
     session: ClientSession? = null
 ): MongoUpload<BsonObjectId> {
     val chunkSize = options.chunkSizeBytes ?: chunkSizeBytes
     val channel = Channel<ByteBuffer>()
     val job = CoroutineScope(Dispatchers.IO).async {
-        upload(channel, filename, options, session)
+        upload(channel, filename, metadata, options, session)
     }
 
     job.invokeOnCompletion { channel.close() }
@@ -80,6 +84,7 @@ suspend fun MongoBucket.asyncUpload(
  *
  * @param session the client session with which to associate this operation.
  * @param filename the filename.
+ * @param metadata user provided data for the `metadata` field of the files collection document.
  * @param options  the upload options.
  * @return an upload instance to complete the upload process.
  * @see com.mongodb.reactivestreams.client.gridfs.GridFSBucket.uploadFromPublisher
@@ -87,9 +92,10 @@ suspend fun MongoBucket.asyncUpload(
  */
 suspend fun MongoBucket.asyncUpload(
     filename: String,
+    metadata: BsonDocumentBlock,
     session: ClientSession? = null,
-    options: UploadOptions.() -> Unit
-) = asyncUpload(filename, UploadOptions(options), session)
+    options: UploadOptions.() -> Unit = {}
+) = asyncUpload(filename, BsonDocument(metadata), UploadOptions(options), session)
 
 //
 
@@ -105,6 +111,7 @@ suspend fun MongoBucket.asyncUpload(
  * @param session the client session with which to associate this operation.
  * @param id       the custom id value of the file.
  * @param filename the filename.
+ * @param metadata user provided data for the `metadata` field of the files collection document.
  * @param options  the upload options.
  * @return an upload instance to complete the upload process.
  * @see com.mongodb.reactivestreams.client.gridfs.GridFSBucket.uploadFromPublisher
@@ -113,13 +120,14 @@ suspend fun MongoBucket.asyncUpload(
 suspend fun MongoBucket.asyncUpload(
     filename: String,
     id: BsonElement,
+    metadata: BsonDocument = BsonDocument.Empty,
     options: UploadOptions = UploadOptions(),
     session: ClientSession? = null
 ): MongoUpload<Unit> {
     val chunkSize = options.chunkSizeBytes ?: chunkSizeBytes
     val channel = Channel<ByteBuffer>()
     val job = CoroutineScope(Dispatchers.IO).async {
-        upload(channel, filename, id, options, session)
+        upload(channel, filename, id, metadata, options, session)
     }
 
     job.invokeOnCompletion { channel.close() }
@@ -143,6 +151,7 @@ suspend fun MongoBucket.asyncUpload(
  * @param session the client session with which to associate this operation.
  * @param id       the custom id value of the file.
  * @param filename the filename.
+ * @param metadata user provided data for the `metadata` field of the files collection document.
  * @param options  the upload options.
  * @return an upload instance to complete the upload process.
  * @see com.mongodb.reactivestreams.client.gridfs.GridFSBucket.uploadFromPublisher
@@ -151,9 +160,10 @@ suspend fun MongoBucket.asyncUpload(
 suspend fun MongoBucket.asyncUpload(
     filename: String,
     id: BsonElement,
+    metadata: BsonDocumentBlock,
     session: ClientSession? = null,
-    options: UploadOptions.() -> Unit
-) = asyncUpload(filename, id, UploadOptions(options), session)
+    options: UploadOptions.() -> Unit = {}
+) = asyncUpload(filename, id, BsonDocument(metadata), UploadOptions(options), session)
 
 /* ============= ------------------ ============= */
 

--- a/coroutines/src/main/kotlin/gridfs/Options.kt
+++ b/coroutines/src/main/kotlin/gridfs/Options.kt
@@ -44,14 +44,7 @@ data class UploadOptions(
      * @see com.mongodb.client.gridfs.model.GridFSUploadOptions.chunkSizeBytes
      * @since 2.0.0
      */
-    var chunkSizeBytes: Int? = null,
-    /**
-     * Returns any user provided data for the `metadata` field of the files collection document.
-     *
-     * @see com.mongodb.client.gridfs.model.GridFSUploadOptions.metadata
-     * @since 2.0.0
-     */
-    var metadata: BsonDocument? = null
+    var chunkSizeBytes: Int? = null
 )
 
 /* ============= ------------------ ============= */

--- a/coroutines/src/main/kotlin/gridfs/internal/MongoBucketOverloads.kt
+++ b/coroutines/src/main/kotlin/gridfs/internal/MongoBucketOverloads.kt
@@ -1,0 +1,95 @@
+/*
+ *	Copyright 2022-2023 cufy.org and meemer.com
+ *
+ *	Licensed under the Apache License, Version 2.0 (the "License");
+ *	you may not use this file except in compliance with the License.
+ *	You may obtain a copy of the License at
+ *
+ *	    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *	Unless required by applicable law or agreed to in writing, software
+ *	distributed under the License is distributed on an "AS IS" BASIS,
+ *	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *	See the License for the specific language governing permissions and
+ *	limitations under the License.
+ */
+package org.cufy.mongodb.gridfs.internal
+
+import com.mongodb.client.gridfs.model.GridFSDownloadOptions
+import com.mongodb.reactivestreams.client.gridfs.GridFSDownloadPublisher
+import com.mongodb.reactivestreams.client.gridfs.GridFSUploadPublisher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.reactive.asPublisher
+import org.bson.Document
+import org.cufy.bson.BsonDocument
+import org.cufy.bson.BsonElement
+import org.cufy.bson.ObjectId
+import org.cufy.bson.java.java
+import org.cufy.mongodb.ClientSession
+import org.cufy.mongodb.gridfs.DownloadOptions
+import org.cufy.mongodb.gridfs.FileRevision
+import org.cufy.mongodb.gridfs.UploadOptions
+import org.cufy.mongodb.gridfs.java.JavaMongoBucket
+import org.cufy.mongodb.gridfs.java.apply
+import org.cufy.mongodb.gridfs.java.java
+import java.nio.ByteBuffer
+
+internal fun JavaMongoBucket.uploadFromPublisher0(
+    source: Flow<ByteBuffer>,
+    filename: String,
+    metadata: BsonDocument,
+    options: UploadOptions,
+    session: ClientSession?
+): GridFSUploadPublisher<ObjectId> {
+    val opts = options.java.metadata(Document(metadata.java))
+    val publisher = when (session) {
+        null -> uploadFromPublisher(filename, source.asPublisher(), opts)
+        else -> uploadFromPublisher(session.java, filename, source.asPublisher(), opts)
+    }
+    return publisher
+}
+
+internal fun JavaMongoBucket.uploadFromPublisher0(
+    source: Flow<ByteBuffer>,
+    filename: String,
+    id: BsonElement,
+    metadata: BsonDocument,
+    options: UploadOptions,
+    session: ClientSession?
+): GridFSUploadPublisher<Void> {
+    val opts = options.java.metadata(Document(metadata.java))
+    val publisher = when (session) {
+        null -> uploadFromPublisher(id.java, filename, source.asPublisher(), opts)
+        else -> uploadFromPublisher(session.java, id.java, filename, source.asPublisher(), opts)
+    }
+    return publisher
+}
+
+internal fun JavaMongoBucket.downloadToPublisher0(
+    id: BsonElement,
+    options: DownloadOptions,
+    session: ClientSession?
+): GridFSDownloadPublisher {
+    val publisher = when (session) {
+        null -> downloadToPublisher(id.java)
+        else -> downloadToPublisher(session.java, id.java)
+    }
+    publisher.apply(options)
+    return publisher
+}
+
+internal fun JavaMongoBucket.downloadToPublisher0(
+    filename: String,
+    options: DownloadOptions,
+    revision: FileRevision,
+    session: ClientSession?
+): GridFSDownloadPublisher {
+    val opts = GridFSDownloadOptions().revision(revision.value)
+    val publisher = when (session) {
+        null -> downloadToPublisher(filename, opts)
+        else -> downloadToPublisher(session.java, filename, opts)
+    }
+    publisher.apply(options)
+    return publisher
+}
+

--- a/coroutines/src/main/kotlin/gridfs/internal/MongoDownloadImpl.kt
+++ b/coroutines/src/main/kotlin/gridfs/internal/MongoDownloadImpl.kt
@@ -20,17 +20,19 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.getOrElse
 import kotlinx.coroutines.runBlocking
 import org.cufy.mongodb.gridfs.MongoDownload
+import org.cufy.mongodb.gridfs.MongoFile
 import java.io.InputStream
 import java.nio.ByteBuffer
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.math.min
 
-internal class MongoDownloadImpl<T>(
-    job: Deferred<T>,
+internal class MongoDownloadImpl(
+    job: Deferred<Unit>,
+    override val file: Deferred<MongoFile>,
     private val channel: ReceiveChannel<ByteBuffer>,
     override val bufferSizeBytes: Int,
     val onClose: () -> Unit
-) : MongoDownload<T>, Deferred<T> by job {
+) : MongoDownload, Deferred<Unit> by job {
     override fun close() {
         leftover.set(null)
         onClose()
@@ -66,7 +68,7 @@ internal class MongoDownloadImpl<T>(
     }
 }
 
-internal class MongoDownloadInputStream(private val descriptor: MongoDownload<*>) : InputStream() {
+internal class MongoDownloadInputStream(private val descriptor: MongoDownload) : InputStream() {
     override fun read(): Int {
         val bytes = ByteArray(1)
         runBlocking { descriptor.read(bytes) }

--- a/coroutines/src/main/kotlin/gridfs/internal/MongoUploadImpl.kt
+++ b/coroutines/src/main/kotlin/gridfs/internal/MongoUploadImpl.kt
@@ -19,16 +19,18 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.runBlocking
+import org.cufy.bson.BsonElement
 import org.cufy.mongodb.gridfs.MongoUpload
 import java.io.OutputStream
 import java.nio.ByteBuffer
 
-internal class MongoUploadImpl<T>(
-    job: Deferred<T>,
+internal class MongoUploadImpl(
+    job: Deferred<Unit>,
+    override val id: Deferred<BsonElement>,
     private val channel: SendChannel<ByteBuffer>,
     override val chunkSizeBytes: Int,
     private val onClose: () -> Unit
-) : MongoUpload<T>, Deferred<T> by job {
+) : MongoUpload, Deferred<Unit> by job {
     @OptIn(ExperimentalCoroutinesApi::class)
     override val isClosedForWrite get() = channel.isClosedForSend
     override fun close() = onClose()
@@ -53,7 +55,7 @@ internal class MongoUploadImpl<T>(
     }
 }
 
-internal class MongoUploadOutputStream(private val descriptor: MongoUpload<*>) : OutputStream() {
+internal class MongoUploadOutputStream(private val descriptor: MongoUpload) : OutputStream() {
     override fun write(b: Int) {
         val buffer = ByteArray(1)
         buffer[0] = b.toByte()

--- a/coroutines/src/main/kotlin/gridfs/java/Options.kt
+++ b/coroutines/src/main/kotlin/gridfs/java/Options.kt
@@ -15,7 +15,6 @@
  */
 package org.cufy.mongodb.gridfs.java
 
-import org.bson.Document
 import org.cufy.bson.java.java
 import org.cufy.mongodb.gridfs.BucketFindOptions
 import org.cufy.mongodb.gridfs.DownloadOptions
@@ -35,7 +34,6 @@ val UploadOptions.java: JavaUploadOptions
     get() {
         return JavaUploadOptions()
             .chunkSizeBytes(chunkSizeBytes)
-            .metadata(metadata?.java?.let { Document(it) })
     }
 
 /* ============= ------------------ ============= */


### PR DESCRIPTION
- moved metadata to be a parameter when uploading instead of being in the options
- added `download.file` and `upload.id` to allow getting these values before completing the upload or download
- removed generics from `MongoUpload` and `MongoDownload`

